### PR TITLE
Add GitHub Actions workflow to publish Python package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build sdist & wheel from pyproject.toml
+        run: python -m build --sdist --wheel --outdir dist/
+
+      - name: Publish to PyPI (Trusted Publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This workflow automates package publishing on PyPI upon tagging a release. It builds source distributions and wheels, ensuring compatibility and compliance with PyPI's standards. Trusted Publisher credentials are used to securely publish the package.